### PR TITLE
Set architect context for push-to-app-catalog job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,6 +6,7 @@ workflows:
   package-and-push-chart-on-tag:
     jobs:
       - architect/push-to-app-catalog:
+          context: "architect"
           name: "package and push {CHART-NAME} chart"
           app_catalog: "giantswarm-playground-catalog"
           app_catalog_test: "giantswarm-playground-test-catalog"


### PR DESCRIPTION
See https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/adding_app_to_appcatalog/ and https://gigantic.slack.com/archives/C04TGHDEF/p1589533095301400