### PR TITLE
Remove app suffix requirement from template-app

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,11 @@
 Giant Swarm offers a {APP-NAME} App which can be installed in tenant clusters.
 Here we define the {APP-NAME} chart with its templates and default configuration.
 
-Basic info:
-**What is it?**
-**Why did we add it?**
-**Who can use it?**
-**How to use it?**
+Basic info:  
+**What is it?**  
+**Why did we add it?**  
+**Who can use it?**  
+**How to use it?**  
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,63 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/{APP-NAME}-app.svg?style=shield)](https://circleci.com/gh/giantswarm/{APP-NAME}-app)
+[![CircleCI](https://circleci.com/gh/giantswarm/{APP-NAME}.svg?style=shield)](https://circleci.com/gh/giantswarm/{APP-NAME})
 
-# {APP-NAME}-app chart
+# {APP-NAME} chart
 
-Giant Swarm offers a {APP-NAME} Managed App which can be installed in tenant clusters.
+Giant Swarm offers a {APP-NAME} App which can be installed in tenant clusters.
 Here we define the {APP-NAME} chart with its templates and default configuration.
+
+Basic info:
+**What is it?**
+**Why did we add it?**
+**Who can use it?**
+**How to use it?**
+
+## Installing
+
+There are 3 ways to install this app onto a tenant cluster.
+
+1. [Using our web interface](https://docs.giantswarm.io/reference/web-interface/app-catalog/)
+2. [Using our API](https://docs.giantswarm.io/api/#operation/createClusterAppV5)
+3. Directly creating the App custom resource on the Control Plane.
+
+## Configuring
+
+### values.yaml
+**This is an example of the values file you could upload using our web interface.**
+```
+# values.yaml
+
+```
+
+### Sample App CR and ConfigMap for the Control Plane
+If you have access to the Kubernetes API on the Control Plane, you could create
+the App CR and ConfigMap directly.
+
+Here is an example that would install the nginx-ingress-controller-app to
+tenant cluster `abc12`:
+
+```
+# appCR.yaml
+
+```
+
+```
+# user-values-configmap.yaml
+
+
+```
+
+See our [full reference page on how to configure applications](https://docs.giantswarm.io/reference/app-configuration/) for more details.
+
+## Compatability
+
+This app has been tested to work with the following tenant cluster release versions:
+- 
+
+## Limitations
+
+Some apps have restrictions on how they can be deployed.
+Not following these limitations will most likely result in a broken deployment.
+- 
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,9 @@
 Giant Swarm offers a {APP-NAME} App which can be installed in tenant clusters.
 Here we define the {APP-NAME} chart with its templates and default configuration.
 
-Basic info:  
-**What is it?**  
+**What is this app?**  
 **Why did we add it?**  
 **Who can use it?**  
-**How to use it?**  
 
 ## Installing
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are 3 ways to install this app onto a tenant cluster.
 If you have access to the Kubernetes API on the Control Plane, you could create
 the App CR and ConfigMap directly.
 
-Here is an example that would install the nginx-ingress-controller-app to
+Here is an example that would install the app to
 tenant cluster `abc12`:
 
 ```

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ There are 3 ways to install this app onto a tenant cluster.
 ## Configuring
 
 ### values.yaml
-**This is an example of the values file you could upload using our web interface.**
+**This is an example of a values file you could upload using our web interface.**
 ```
 # values.yaml
 
@@ -49,13 +49,13 @@ See our [full reference page on how to configure applications](https://docs.gian
 ## Compatability
 
 This app has been tested to work with the following tenant cluster release versions:
-- 
+* 
 
-## Limitations
+## Limitations  
 
 Some apps have restrictions on how they can be deployed.
 Not following these limitations will most likely result in a broken deployment.
-- 
+* 
 
 ## Credit
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://circleci.com/gh/giantswarm/{APP-NAME}.svg?style=shield)](https://circleci.com/gh/giantswarm/{APP-NAME})
+[![CircleCI](https://circleci.com/gh/giantswarm/{APP-NAME}-app.svg?style=shield)](https://circleci.com/gh/giantswarm/{APP-NAME}-app)
 
 # {APP-NAME} chart
 

--- a/helm/APP-NAME-app/Chart.yaml
+++ b/helm/APP-NAME-app/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 appVersion: 0.0.1
 description: A Helm chart for {APP-NAME}
 engine: gotpl
-home: https://github.com/giantswarm/{APP-NAME}
+home: https://github.com/giantswarm/{APP-NAME}-app
 icon: https://some.domain.com/logo.png
 name: {APP-NAME}
 sources:

--- a/helm/APP-NAME-app/Chart.yaml
+++ b/helm/APP-NAME-app/Chart.yaml
@@ -2,9 +2,9 @@ apiVersion: v1
 appVersion: 0.0.1
 description: A Helm chart for {APP-NAME}
 engine: gotpl
-home: https://github.com/giantswarm/{APP-NAME}-app
+home: https://github.com/giantswarm/{APP-NAME}
 icon: https://some.domain.com/logo.png
-name: {APP-NAME}-app
+name: {APP-NAME}
 sources:
 - https://github.com/some-org/some-repo
 version: [[ .Version ]]

--- a/helm/APP-NAME-app/values.yaml
+++ b/helm/APP-NAME-app/values.yaml
@@ -1,6 +1,6 @@
 # TEMPLATE-APP: This is set as a reasonable default, feel free to change.
 
-name: {APP-NAME}-app
+name: {APP-NAME}
 namespace: kube-system
 serviceType: managed
 
@@ -10,6 +10,6 @@ project:
 
 image:
   registry: quay.io
-  name: giantswarm/{APP-NAME}-app
+  name: giantswarm/{APP-NAME}
   tag: v0.0.1
   pullPolicy: IfNotPresent


### PR DESCRIPTION
Towards https://github.com/giantswarm/giantswarm/issues/9815

1. I also added template for adding basic info about the app from the app issue https://github.com/giantswarm/giantswarm/issues/new?assignees=&labels=area%2Fmanaged-apps%2C+team%2Fhalo&template=new-app-in-catalog-preview.md&title=
2. I also added the sample readme outline from https://intranet.giantswarm.io/docs/dev-and-releng/app-developer-processes/apps_in_happa/

The idea is they are easy to fill out while the App Engineer is adding an app. Do you think this is reasonable to include in the template? 