### PR TITLE
Add info on name and description

### DIFF
--- a/helm/APP-NAME/Chart.yaml
+++ b/helm/APP-NAME/Chart.yaml
@@ -1,7 +1,12 @@
 apiVersion: v1
 appVersion: 0.0.1
+
+# Please make sure your name DOES NOT end in "app" or "-app".
 name: {APP-NAME}
-description: A Helm chart for {APP-NAME}
+
+# Please describe what the app provides in a sentence or two.
+description: Please add description
+
 engine: gotpl
 home: https://github.com/giantswarm/{APP-NAME}-app
 


### PR DESCRIPTION
This PR attempts to improve the quality of the metadata of apps built on top of it.

We often have app names ending in `-app`, which is OK for a repo, but not great for an app name.

Also we often see descriptions like "Helm chart for whatever", which is not helpful at all.