### PR TITLE
Remove engine key, update version to v2

### DIFF
--- a/helm/APP-NAME/Chart.yaml
+++ b/helm/APP-NAME/Chart.yaml
@@ -1,4 +1,4 @@
-apiVersion: v1
+apiVersion: v2
 appVersion: 0.0.1
 
 # Please make sure your name DOES NOT end in "app" or "-app".

--- a/helm/APP-NAME/Chart.yaml
+++ b/helm/APP-NAME/Chart.yaml
@@ -7,7 +7,6 @@ name: {APP-NAME}
 # Please describe what the app provides in a sentence or two.
 description: Please add description
 
-engine: gotpl
 home: https://github.com/giantswarm/{APP-NAME}-app
 
 # If you have an icon/logo, you should add it to https://github.com/giantswarm/web-assets


### PR DESCRIPTION
- `engine` key is not documented and doesn't serve a purpose
- As the app platform uses Helm 3, new apps should use apiVersion v2