### PR TITLE
Set version to 0.0.0-dev

### DIFF
--- a/helm/APP-NAME/Chart.yaml
+++ b/helm/APP-NAME/Chart.yaml
@@ -15,7 +15,7 @@ home: https://github.com/giantswarm/{APP-NAME}-app
 
 sources:
 - https://github.com/some-org/some-repo
-version: 0.1.0 # [[ .Version ]] if you're using architect instead of app-build-suite
+version: 0.0.0-dev # [[ .Version ]] if you're using architect instead of app-build-suite
 annotations:
   branch: my-branch # Used through .Chart.Annotations.branch (This is not replaced automatically)
   commit: f00bar # Used through .Chart.Annotations.commit (This is not replaced automatically)


### PR DESCRIPTION
I found it confusing to find it was 0.1.0 in some projects. I think using 0.0.0-dev here is a clearer message it will be replaced during the build time.