### PR TITLE
switch branch in changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/master
+[Unreleased]: https://github.com/giantswarm/REPOSITORY_NAME/tree/main


### PR DESCRIPTION
This PR:

- changes the branch listed in the changelog as cloned repos default to `main`
