### PR TITLE
change label group from 'app' to 'application'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,4 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- changed: `app.giantswarm.io` label group was changed to `application.giantswarm.io`
+
 [Unreleased]: https://github.com/giantswarm/{APP-NAME}/tree/main

--- a/helm/APP-NAME/templates/_helpers.tpl
+++ b/helm/APP-NAME/templates/_helpers.tpl
@@ -27,9 +27,9 @@ Common labels
 {{- define "labels.common" -}}
 {{ include "labels.selector" . }}
 app.giantswarm.io/branch: {{ .Chart.Annotations.branch | replace "#" "-" | replace "/" "-" | replace "." "-" | trunc 63 | trimSuffix "-" | quote }}
-app.giantswarm.io/commit: {{ .Chart.Annotations.commit | quote }}
-app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+application.giantswarm.io/commit: {{ .Chart.Annotations.commit | quote }}
+application.kubernetes.io/managed-by: {{ .Release.Service | quote }}
+application.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
 application.giantswarm.io/team: {{ index .Chart.Annotations "application.giantswarm.io/team" | quote }}
 giantswarm.io/managed-by: {{ .Release.Name | quote }}
 giantswarm.io/service-type: {{ .Values.serviceType }}


### PR DESCRIPTION
Fixing: https://github.com/giantswarm/giantswarm/issues/22473

This PR:

- all our CRDs use `application.giantswarm.io`, so it's fixed here now as well