### PR TITLE
Update CircleCI config with latest architect-orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,16 +1,16 @@
 version: 2.1
 orbs:
-  architect: giantswarm/architect@4.8.1
+  architect: giantswarm/architect@4.35.5
 
 workflows:
   package-and-push-chart-on-tag:
     jobs:
       - architect/push-to-app-catalog:
-          context: "architect"
-          executor: "app-build-suite"
-          name: "package and push {APP-NAME} chart"
-          app_catalog: "giantswarm-playground-catalog"
-          app_catalog_test: "giantswarm-playground-test-catalog"
+          context: architect
+          executor: app-build-suite
+          name: package-and-push-chart
+          app_catalog: giantswarm-playground-catalog
+          app_catalog_test: giantswarm-playground-test-catalog
           chart: "{APP-NAME}"
           # Trigger job on git tag.
           filters:


### PR DESCRIPTION
This updates the template with latest architect-orb and removes the app name from the job name.