### PR TITLE
Fix CircleCI badge app name replacement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![CircleCI](https://dl.circleci.com/status-badge/img/gh/giantswarm/APP-NAME/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/giantswarm/APP-NAME/tree/main)
+[![CircleCI](https://dl.circleci.com/status-badge/img/gh/giantswarm/{APP-NAME}/tree/main.svg?style=svg)](https://dl.circleci.com/status-badge/redirect/gh/giantswarm/{APP-NAME}/tree/main)
 
 [Read me after cloning this template (GS staff only)](https://handbook.giantswarm.io/docs/dev-and-releng/app-developer-processes/adding_app_to_appcatalog/)
 


### PR DESCRIPTION
See [replacement instructions](https://handbook.giantswarm.io/docs/dev-and-releng/repository/app/) which only uses `{APP-NAME}` as placeholder.